### PR TITLE
feat: slider for reminder size and larger size presets

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -214,8 +214,8 @@
         </select>
       </div>
       <div class="form-group" id="customSizeGroup" style="display:none;">
-        <label for="customSize">Custom Size:</label>
-        <input type="text" id="customSize" placeholder="Enter custom size (e.g. 32px)" />
+        <label for="customSize">Custom Size: <span id="customSizeValue"></span>px</label>
+        <input type="range" id="customSize" min="16" max="100" value="32" />
       </div>
 
       <button type="submit">Save Settings</button>
@@ -234,7 +234,9 @@
         document.getElementById('reminderSize').value = data.reminderSize;
       } else {
         document.getElementById('reminderSize').value = 'custom';
-        document.getElementById('customSize').value = data.reminderSize || '';
+        const customValue = parseInt(data.reminderSize, 10) || 32;
+        document.getElementById('customSize').value = customValue;
+        document.getElementById('customSizeValue').innerText = customValue;
       }
       updateCustomVisibility();
     });
@@ -246,7 +248,7 @@
       fetch('/settings', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: new URLSearchParams({ showQR, qrPosition, reminderPosition: document.getElementById('reminderPosition').value, reminderSize: document.getElementById('reminderSize').value, customSize: document.getElementById('customSize').value })
+        body: new URLSearchParams({ showQR, qrPosition, reminderPosition: document.getElementById('reminderPosition').value, reminderSize: document.getElementById('reminderSize').value, customSize: document.getElementById('customSize').value + 'px' })
       }).then(res => res.json()).then(data => {
         document.getElementById('saveStatus').innerText = data.success ? "✅ Saved" : "❌ Failed";
       });
@@ -335,11 +337,19 @@
 <script>
   const sizeDropdown = document.getElementById('reminderSize');
   const customGroup = document.getElementById('customSizeGroup');
+  const customSlider = document.getElementById('customSize');
+  const customSizeValue = document.getElementById('customSizeValue');
   function updateCustomVisibility() {
     customGroup.style.display = sizeDropdown.value === 'custom' ? 'block' : 'none';
   }
   sizeDropdown.addEventListener('change', updateCustomVisibility);
   updateCustomVisibility();
+
+  function updateCustomDisplay() {
+    customSizeValue.innerText = customSlider.value;
+  }
+  customSlider.addEventListener('input', updateCustomDisplay);
+  updateCustomDisplay();
 
   const themeToggle = document.getElementById('themeToggle');
   function applyTheme(t) {

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
       r.style.top = '';
       r.style.bottom = '';
       r.style.transform = '';
-      r.style.fontSize = size === 'small' ? '16px' : size === 'medium' ? '24px' : size === 'large' ? '32px' : size;
+      r.style.fontSize = size === 'small' ? '24px' : size === 'medium' ? '36px' : size === 'large' ? '48px' : size;
 
       if (placement === 'top') {
         r.style.top = '0';


### PR DESCRIPTION
## Summary
- replace custom reminder size text box with a range slider and live value display
- send custom slider value in pixels and parse saved size
- enlarge built-in reminder sizes to 24/36/48px

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688da93555608328b84dbeb51556520a