### PR TITLE
Migrate display to HTTP-backed web UI; add server improvements and multiplatform README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,90 @@
-# Parcina Slideshow Display
+# Parcina Display
 
-A personalized fullscreen slideshow and dashboard app created for Parcina, designed to:
+Parcina Display is a local-first slideshow and reminder display app. It started as a Windows/Electron room display, and the current codebase is being moved toward a multiplatform product that can run on desktops, tablets, and browser-based shells.
 
-- Show a continuous fullscreen photo slideshow
-- Display custom reminders (e.g. in Bengali/English)
-- Auto start and stop via Task Scheduler
-- Allow QR code-based photo uploads
-- Support remote configuration via a browser-accessible dashboard
+## What it does today
 
-## 🔧 Features
+- Shows a fullscreen photo slideshow.
+- Displays rotating reminders in large, configurable text.
+- Hosts a local dashboard for uploading photos and changing settings.
+- Generates a QR code that points family/caregivers to the dashboard on the same Wi-Fi network.
+- Runs in Electron for desktop display mode or in any browser connected to the local Express server.
 
-- **Electron-based app** with fullscreen display
-- **Dashboard** with settings for:
-  - QR code visibility and placement
-  - Custom reminders (single-line format)
-- **Photo upload server** protected by a password
-- **Auto start/stop** and screen dimming support
-- Designed for **long-term care semi-private rooms**
+## Multiplatform direction
 
-## 📂 Folder Structure
+The app is now structured around a browser-compatible display route (`/`) backed by HTTP APIs instead of Electron-only filesystem access. This is the first step toward wrapping the same app core for:
 
-- `/dist/` – build output (excluded from Git)
-- `/C:/Photos/` – image folder for slideshow & `reminders.txt`
-- `server.js` – Express.js server for dashboard + uploads
-- `main.js` – Electron launcher for the fullscreen app
+- Windows and macOS using Electron or Tauri.
+- iPad, Android tablets, and Amazon Fire tablets using Capacitor.
+- Browser/PWA deployments for testing and local-network use.
 
-## 🚀 Getting Started
+## Project files
+
+- `server.js` - Express server for the display, dashboard, photo uploads, settings, and reminders.
+- `index.html` - Browser-compatible slideshow display.
+- `dashboard.html` - Local dashboard for uploads, gallery management, reminders, and settings.
+- `main.js` - Electron launcher that starts the local server and opens the display route.
+- `generateQR.js` - QR code generator for the local dashboard URL.
+
+## Getting started
+
+Install dependencies:
 
 ```bash
 npm install
+```
+
+Run the desktop display with Electron:
+
+```bash
 npm start
+```
 
-Or build for deployment:
-npm run build
+Run only the local web server:
 
-🛡️ Local Configuration
-Store photos in C:/Photos/
+```bash
+npm run start:web
+```
 
-Add reminders in reminders.txt (one per line)
+Then open:
 
-Settings saved in settings.json
+- Display: `http://localhost:8080/`
+- Dashboard: `http://localhost:8080/dashboard`
 
-🧠 Made with ❤️ for Parcina (mom)
-By Thahrim (@thahrim) — built for accessibility, ease, and love.
+## Storage configuration
+
+By default, Parcina Display stores app data in a platform-appropriate user data directory:
+
+- Windows: `%APPDATA%/Parcina Display`
+- macOS: `~/Library/Application Support/Parcina Display`
+- Linux: `$XDG_DATA_HOME/parcina-display` or `~/.local/share/parcina-display`
+
+Photos are stored in a `photos` folder under that data directory. You can override these paths with environment variables:
+
+```bash
+PARCINA_DATA_DIR=/path/to/data npm run start:web
+PARCINA_PHOTOS_DIR=/path/to/photos npm run start:web
+PARCINA_SETTINGS_PATH=/path/to/settings.json npm run start:web
+PARCINA_REMINDERS_PATH=/path/to/reminders.txt npm run start:web
+```
+
+For the original Windows-style storage layout, set:
+
+```powershell
+$env:PARCINA_PHOTOS_DIR = "C:/Photos"
+npm start
+```
+
+## Build commands
+
+Current desktop packaging command for Windows:
+
+```bash
+npm run build:win
+```
+
+Future app-store work should add Capacitor iOS/Android projects and desktop release packaging after the shared web app is migrated into a modern React/TypeScript frontend.
+
+## Privacy and network note
+
+The current app is intended for trusted local networks. Before public app-store distribution, protect dashboard write actions with authentication and prepare privacy disclosures for photo access, local-network access, reminders, and any future cloud features.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="bn">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Parcina's Display</title>
   <style>
     body {
@@ -19,6 +20,17 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
+    }
+    #emptyState {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: rgba(255,255,255,0.7);
+      text-align: center;
+      padding: 2rem;
+      font-size: clamp(1.25rem, 3vw, 2.5rem);
     }
     #reminder {
       position: fixed;
@@ -45,19 +57,11 @@
 </head>
 <body>
   <div id="slideshow"></div>
+  <div id="emptyState">Add photos from the dashboard to start the display.</div>
   <div id="reminder">লোড হচ্ছে... / Loading...</div>
-  <div id="qr"><img src="qr.png" alt="QR Code to upload" /></div>
+  <div id="qr"><img src="/qr.png" alt="QR Code to upload" /></div>
 
   <script>
-  const { ipcRenderer } = require('electron');
-  const fs = require('fs');
-  const path = require('path');
-
-  const imageFolder = 'C:/Photos';
-  const reminderFile = path.join(imageFolder, 'reminders.txt');
-  const settingsFile = path.join(__dirname, 'settings.json');
-  const validExtensions = ['.jpg', '.jpeg', '.png', '.bmp', '.gif'];
-
   let imageFilenames = [];
   let reminders = [];
   let currentImage = 0;
@@ -65,93 +69,107 @@
   let hasShuffled = false;
 
   const slideshow = document.getElementById('slideshow');
+  const emptyState = document.getElementById('emptyState');
   const reminder = document.getElementById('reminder');
   const qrDiv = document.getElementById('qr');
 
-  function loadSettings() {
+  async function fetchJson(url, fallback) {
     try {
-      const settings = JSON.parse(fs.readFileSync(settingsFile, 'utf-8'));
-      console.log("✅ Loaded settings:", settings);
-
-      if (!settings.showQR) {
-        qrDiv.style.display = 'none';
-      } else {
-        qrDiv.style.display = 'block';
-        qrDiv.style.top = '';
-        qrDiv.style.bottom = '';
-        qrDiv.style.left = '';
-        qrDiv.style.right = '';
-
-        const position = settings.qrPosition || 'bottom-right';
-        const positions = {
-          'top-left': { top: '10px', left: '10px' },
-          'top-right': { top: '10px', right: '10px' },
-          'bottom-left': { bottom: '10px', left: '10px' },
-          'bottom-right': { bottom: '10px', right: '10px' }
-        };
-        Object.assign(qrDiv.style, positions[position]);
-
-        console.log(`📍 QR repositioned to: ${position}`);
-      const r = document.getElementById('reminder');
-      const placement = settings.reminderPosition || 'bottom';
-      const size = settings.reminderSize || 'medium';
-      r.style.top = '';
-      r.style.bottom = '';
-      r.style.transform = '';
-      r.style.fontSize = size === 'small' ? '24px' : size === 'medium' ? '36px' : size === 'large' ? '48px' : size;
-
-      if (placement === 'top') {
-        r.style.top = '0';
-      } else if (placement === 'center') {
-        r.style.top = '50%';
-        r.style.transform = 'translateY(-50%)';
-      } else {
-        r.style.bottom = '0';
-      }
-
-      }
-    } catch (err) {
-      console.error('Error loading settings:', err);
+      const response = await fetch(url, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+      return await response.json();
+    } catch (error) {
+      console.error(`Could not load ${url}:`, error);
+      return fallback;
     }
   }
 
-  function loadImages() {
-    try {
-      const newList = fs.readdirSync(imageFolder).filter(file =>
-        validExtensions.includes(path.extname(file).toLowerCase())
-      );
+  function applySettings(settings) {
+    if (!settings.showQR) {
+      qrDiv.style.display = 'none';
+    } else {
+      qrDiv.style.display = 'block';
+      qrDiv.style.top = '';
+      qrDiv.style.bottom = '';
+      qrDiv.style.left = '';
+      qrDiv.style.right = '';
 
-      if (!hasShuffled) {
-        for (let i = newList.length - 1; i > 0; i--) {
-          const j = Math.floor(Math.random() * (i + 1));
-          [newList[i], newList[j]] = [newList[j], newList[i]];
-        }
-        hasShuffled = true;
-      }
+      const position = settings.qrPosition || 'bottom-right';
+      const positions = {
+        'top-left': { top: '10px', left: '10px' },
+        'top-right': { top: '10px', right: '10px' },
+        'bottom-left': { bottom: '10px', left: '10px' },
+        'bottom-right': { bottom: '10px', right: '10px' }
+      };
+      Object.assign(qrDiv.style, positions[position] || positions['bottom-right']);
+    }
 
-      imageFilenames = newList;
-    } catch (e) {
-      console.error('Image folder error:', e);
+    const placement = settings.reminderPosition || 'bottom';
+    const size = settings.reminderSize || 'medium';
+    reminder.style.top = '';
+    reminder.style.bottom = '';
+    reminder.style.transform = 'translateX(-50%)';
+    reminder.style.fontSize = size === 'small' ? '24px' : size === 'medium' ? '36px' : size === 'large' ? '48px' : size;
+
+    if (placement === 'top') {
+      reminder.style.top = '0';
+    } else if (placement === 'center') {
+      reminder.style.top = '50%';
+      reminder.style.transform = 'translate(-50%, -50%)';
+    } else {
+      reminder.style.bottom = '0';
     }
   }
 
-  function loadReminders() {
-    try {
-      const lines = fs.readFileSync(reminderFile, 'utf-8')
-        .split('\n')
-        .map(line => line.trim())
-        .filter(Boolean);
-      reminders = lines;
-    } catch (e) {
-      reminders = ['No reminders found'];
+  async function loadSettings() {
+    const settings = await fetchJson('/settings', {
+      showQR: true,
+      qrPosition: 'bottom-right',
+      reminderPosition: 'bottom',
+      reminderSize: 'medium'
+    });
+    applySettings(settings);
+  }
+
+  function shuffleOnce(files) {
+    if (hasShuffled) return files;
+
+    const shuffled = [...files];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    hasShuffled = true;
+    return shuffled;
+  }
+
+  async function loadImages() {
+    const newList = await fetchJson('/photos', []);
+    imageFilenames = shuffleOnce(newList);
+
+    if (currentImage >= imageFilenames.length) {
+      currentImage = 0;
+    }
+  }
+
+  async function loadReminders() {
+    const data = await fetchJson('/reminders', { reminders: ['No reminders found'] });
+    reminders = data.reminders && data.reminders.length ? data.reminders : ['No reminders found'];
+
+    if (currentReminder >= reminders.length) {
+      currentReminder = 0;
     }
   }
 
   function updateImage() {
-    if (!imageFilenames.length) return;
     slideshow.innerHTML = '';
+    emptyState.style.display = imageFilenames.length ? 'none' : 'flex';
+
+    if (!imageFilenames.length) return;
+
     const img = document.createElement('img');
-    img.src = `file:///${imageFolder}/${imageFilenames[currentImage]}`;
+    img.src = `/photos/${encodeURIComponent(imageFilenames[currentImage])}`;
+    img.alt = '';
     slideshow.appendChild(img);
   }
 
@@ -161,54 +179,41 @@
   }
 
   function nextImage() {
+    if (!imageFilenames.length) return;
     currentImage = (currentImage + 1) % imageFilenames.length;
     updateImage();
   }
 
   function previousImage() {
+    if (!imageFilenames.length) return;
     currentImage = (currentImage - 1 + imageFilenames.length) % imageFilenames.length;
     updateImage();
   }
 
   function nextReminder() {
+    if (!reminders.length) return;
     currentReminder = (currentReminder + 1) % reminders.length;
     updateReminder();
   }
 
+  async function refreshContent() {
+    await Promise.all([loadImages(), loadReminders(), loadSettings()]);
+    updateImage();
+    updateReminder();
+  }
+
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') {
-      ipcRenderer.send('quit-app');
-    } else if (e.key === 'ArrowRight') {
+    if (e.key === 'ArrowRight') {
       nextImage();
     } else if (e.key === 'ArrowLeft') {
       previousImage();
     }
   });
 
-  loadSettings();
-  loadImages();
-  loadReminders();
-  updateImage();
-  updateReminder();
-
+  refreshContent();
   setInterval(nextImage, 10000);
   setInterval(nextReminder, 15000);
-
-  fs.watch(imageFolder, (eventType, filename) => {
-    if (validExtensions.includes(path.extname(filename || '').toLowerCase())) {
-      loadImages();
-      updateImage();
-    }
-  });
-
-  fs.watch(reminderFile, () => {
-    loadReminders();
-    updateReminder();
-  });
-
-  fs.watch(settingsFile, () => {
-    loadSettings();
-  });
+  setInterval(refreshContent, 5000);
 </script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -15,12 +15,12 @@ function createWindow () {
     frame: false,
     autoHideMenuBar: true,
     webPreferences: {
-      nodeIntegration: true,
-      contextIsolation: false
+      nodeIntegration: false,
+      contextIsolation: true
     }
   });
 
-  win.loadFile('index.html');
+  win.loadURL('http://localhost:8080/');
 }
 
 app.whenReady().then(createWindow);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Slideshow and reminder display for Parcina",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "start:web": "node server.js",
+    "build:win": "electron-packager . parcina-slideshow --platform=win32 --arch=x64 --out=dist --overwrite --icon=icon.ico"
   },
   "devDependencies": {
     "electron": "^36.4.0",

--- a/server.js
+++ b/server.js
@@ -3,47 +3,93 @@ const fs = require('fs');
 const path = require('path');
 const ip = require('ip');
 const multer = require('multer');
+
 const app = express();
-const port = 8080;
+const port = Number(process.env.PORT || 8080);
+const defaultSettings = {
+  showQR: true,
+  qrPosition: 'bottom-right',
+  reminderPosition: 'bottom',
+  reminderSize: 'medium'
+};
 
-const settingsPath = path.join(__dirname, 'settings.json');
-const remindersPath = path.join('C:/Photos', 'reminders.txt');
-const photosDir = path.join('C:/Photos');
+function getDefaultDataDir() {
+  if (process.platform === 'win32') {
+    return path.join(process.env.APPDATA || process.env.USERPROFILE || __dirname, 'Parcina Display');
+  }
 
-if (!fs.existsSync(settingsPath)) fs.writeFileSync(settingsPath, JSON.stringify({ showQR: true, qrPosition: "bottom-right" }, null, 2));
-if (!fs.existsSync(remindersPath)) fs.writeFileSync(remindersPath, "Move your limbs now");
-if (!fs.existsSync(photosDir)) fs.mkdirSync(photosDir, { recursive: true });
+  if (process.platform === 'darwin') {
+    return path.join(process.env.HOME || __dirname, 'Library', 'Application Support', 'Parcina Display');
+  }
+
+  return path.join(process.env.XDG_DATA_HOME || path.join(process.env.HOME || __dirname, '.local', 'share'), 'parcina-display');
+}
+
+const dataDir = process.env.PARCINA_DATA_DIR || getDefaultDataDir();
+const photosDir = process.env.PARCINA_PHOTOS_DIR || path.join(dataDir, 'photos');
+const settingsPath = process.env.PARCINA_SETTINGS_PATH || path.join(dataDir, 'settings.json');
+const remindersPath = process.env.PARCINA_REMINDERS_PATH || path.join(photosDir, 'reminders.txt');
+
+function ensureFile(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (!fs.existsSync(filePath)) fs.writeFileSync(filePath, contents);
+}
+
+function readSettings() {
+  try {
+    return { ...defaultSettings, ...JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) };
+  } catch {
+    return defaultSettings;
+  }
+}
+
+function safePhotoPath(fileName) {
+  const targetPath = path.resolve(photosDir, fileName);
+  const rootPath = path.resolve(photosDir);
+
+  if (!targetPath.startsWith(rootPath + path.sep)) {
+    return null;
+  }
+
+  return targetPath;
+}
+
+fs.mkdirSync(photosDir, { recursive: true });
+ensureFile(settingsPath, JSON.stringify(defaultSettings, null, 2));
+ensureFile(remindersPath, 'Move your limbs now');
 
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
-app.use('/photos', express.static(photosDir));
-
 const storage = multer.diskStorage({
   destination: (req, file, cb) => cb(null, photosDir),
-  filename: (req, file, cb) => cb(null, Date.now() + '-' + file.originalname)
+  filename: (req, file, cb) => cb(null, Date.now() + '-' + path.basename(file.originalname))
 });
 const upload = multer({ storage });
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.get('/qr.png', (req, res) => {
+  res.sendFile(path.join(__dirname, 'qr.png'));
+});
 
 app.get('/dashboard', (req, res) => {
   res.sendFile(path.join(__dirname, 'dashboard.html'));
 });
 
 app.get('/settings', (req, res) => {
-  try {
-    const settings = JSON.parse(fs.readFileSync(settingsPath));
-    res.json(settings);
-  } catch {
-    res.json({ showQR: true, qrPosition: "bottom-right" });
-  }
+  res.json(readSettings());
 });
 
 app.post('/settings', (req, res) => {
   const newSettings = {
-    showQR: req.body.showQR === "on",
-    qrPosition: req.body.qrPosition || "bottom-right",
-    reminderPosition: req.body.reminderPosition || "bottom",
-    reminderSize: req.body.reminderSize === "custom" ? (req.body.customSize || "32px") : req.body.reminderSize || "medium"
+    showQR: req.body.showQR === 'on' || req.body.showQR === true,
+    qrPosition: req.body.qrPosition || 'bottom-right',
+    reminderPosition: req.body.reminderPosition || 'bottom',
+    reminderSize: req.body.reminderSize === 'custom' ? (req.body.customSize || '32px') : req.body.reminderSize || 'medium'
   };
+
   try {
     fs.writeFileSync(settingsPath, JSON.stringify(newSettings, null, 2));
     res.json({ success: true });
@@ -63,8 +109,13 @@ app.get('/reminders', (req, res) => {
 
 app.post('/reminders', (req, res) => {
   const { reminders } = req.body;
+
+  if (!Array.isArray(reminders)) {
+    return res.status(400).json({ success: false, error: 'reminders must be an array' });
+  }
+
   fs.writeFileSync(remindersPath, reminders.join('\n'));
-  res.json({ success: true });
+  return res.json({ success: true });
 });
 
 app.post('/upload', upload.array('photos'), (req, res) => {
@@ -74,21 +125,35 @@ app.post('/upload', upload.array('photos'), (req, res) => {
 app.get('/photos', (req, res) => {
   fs.readdir(photosDir, (err, files) => {
     if (err) return res.status(500).json([]);
-    const images = files.filter(f => /\.(jpg|jpeg|png|gif)$/i.test(f));
-    res.json(images);
+    const images = files.filter(f => /\.(jpg|jpeg|png|gif|bmp|webp)$/i.test(f));
+    return res.json(images);
   });
 });
+
+app.use('/photos', express.static(photosDir));
 
 app.post('/delete-photo', (req, res) => {
   const { fileName } = req.body;
-  const filePath = path.join(photosDir, fileName);
-  fs.unlink(filePath, err => {
+  const filePath = safePhotoPath(fileName || '');
+
+  if (!filePath) {
+    return res.status(400).json({ success: false });
+  }
+
+  return fs.unlink(filePath, err => {
     if (err) return res.status(500).json({ success: false });
-    res.json({ success: true });
+    return res.json({ success: true });
   });
 });
 
-app.listen(port, () => {
-  const dashboardUrl = `http://${ip.address()}:${port}/dashboard`;
+const server = app.listen(port, () => {
+  const localAddress = ip.address();
+  const displayUrl = `http://${localAddress}:${port}/`;
+  const dashboardUrl = `http://${localAddress}:${port}/dashboard`;
+
+  console.log(`Display available at ${displayUrl}`);
   console.log(`Dashboard available at ${dashboardUrl}`);
+  console.log(`Photos directory: ${photosDir}`);
 });
+
+module.exports = { app, server, paths: { dataDir, photosDir, settingsPath, remindersPath } };


### PR DESCRIPTION
### Motivation

- Move the app from Electron-only filesystem access to a browser-compatible HTTP-backed display so the same core can run in Electron, browsers, and future mobile/desktop wrappers.  
- Replace direct `fs`/IPC usage in the UI with safe server APIs to simplify cross-platform storage and reduce renderer privileges.  
- Make storage paths configurable and safer by using platform-appropriate data directories and path validation.  
- Improve developer ergonomics and documentation for running the app in web or desktop modes.

### Description

- Overhauled `README.md` to document the multiplatform direction, start commands, platform storage locations, and new scripts like `npm run start:web` and `npm run build:win`.  
- Rewrote `index.html` display logic to remove Node/Electron APIs, add a responsive viewport, show an `emptyState`, load images/reminders/settings via `fetch` from server endpoints, add `applySettings`, `shuffleOnce`, and polling via `refreshContent`.  
- Updated `main.js` to harden the renderer by setting `nodeIntegration: false` and `contextIsolation: true` and to load the web display at `http://localhost:8080/` instead of a local file.  
- Substantially refactored `server.js` to add configurable data directories via environment variables, ensure files/dirs exist, serve `index.html` and static `/photos`, expose endpoints for `/settings`, `/reminders`, `/photos`, `/upload`, and `/delete-photo`, validate and sanitize photo paths, extend supported image types, add logging, and export `{ app, server, paths }`.  
- Updated `package.json` to add `start:web` and `build:win` scripts while keeping `start` for Electron.

### Testing

- No automated tests are included in the repository and no automated test suite was executed for this change.
